### PR TITLE
User devices

### DIFF
--- a/lib/rspotify.rb
+++ b/lib/rspotify.rb
@@ -7,6 +7,7 @@ module RSpotify
   autoload :AudioFeatures,      'rspotify/audio_features'
   autoload :Base,               'rspotify/base'
   autoload :Category,           'rspotify/category'
+  autoload :Device,             'rspotify/device'
   autoload :Playlist,           'rspotify/playlist'
   autoload :Recommendations,    'rspotify/recommendations'
   autoload :RecommendationSeed, 'rspotify/recommendation_seed'

--- a/lib/rspotify/device.rb
+++ b/lib/rspotify/device.rb
@@ -8,11 +8,11 @@ module RSpotify
   # @attr [String]      volume_percent  The current volume in percent. This may be null
   class Device < Base
     def initialize(options = {})
-      @id             = options['id'],
-      @is_active      = options['is_active'],
-      @is_restricted  = options['is_restricted'],
-      @name           = options['name'],
-      @type           = options['type'],
+      @id             = options['id']
+      @is_active      = options['is_active']
+      @is_restricted  = options['is_restricted']
+      @name           = options['name']
+      @type           = options['type']
       @volume_percent = options['volume_percent']
     end
   end

--- a/lib/rspotify/device.rb
+++ b/lib/rspotify/device.rb
@@ -1,0 +1,19 @@
+module RSpotify
+
+  # @attr [String]      id              The device ID. This may be null
+  # @attr [Boolean]     is_active       If this device is the currently active device
+  # @attr [Boolean]     is_restricted   Whether controlling this device is restricted. At present if this is "true" then no Web API commands will be accepted by this device.
+  # @attr [String]      name            The name of the device
+  # @attr [String]      type            Device type, such as "Computer", "Smartphone" or "Speaker".
+  # @attr [String]      volume_percent  The current volume in percent. This may be null
+  class Device < Base
+    def initialize(options = {})
+      @id             = options['id'],
+      @is_active      = options['is_active'],
+      @is_restricted  = options['is_restricted'],
+      @name           = options['name'],
+      @type           = options['type'],
+      @volume_percent = options['volume_percent']
+    end
+  end
+end

--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -477,5 +477,13 @@ module RSpotify
       User.oauth_delete(@id, url)
       unfollowed
     end
+
+    def devices
+      url = "me/player/devices"
+      response = RSpotify.resolve_auth_request(@id, url)
+
+      return response if RSpotify.raw_response
+      response['devices'].map { |i| Device.new i }
+    end
   end
 end

--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -478,6 +478,13 @@ module RSpotify
       unfollowed
     end
 
+    # Returns the user's available devices
+    #
+    # @return [Array<Device>]
+    #
+    # @example
+    #           devices = user.devices
+    #           devices.first.id #=> "5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e"
     def devices
       url = "me/player/devices"
       response = RSpotify.resolve_auth_request(@id, url)


### PR DESCRIPTION
# Get a User’s Available Devices

A method to access the following endpoint:
`GET https://api.spotify.com/v1/me/player/devices`

In order to get an **authorized** response from this method:
> The access token must have the user-read-playback-state scope authorized in order to read information.

###

[API Reference](https://developer.spotify.com/web-api/get-a-users-available-devices/)